### PR TITLE
feat: add theme toggle (light/dark/system) and show version in footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A modular, type-safe collection of 27 browser-based developer tools. Built with 
 
 ## What it does
 
-27 tools that run entirely in your browser — no data leaves your machine (except QR generation, which uses an external API). Two languages (EN/IT), automatic dark mode via system preference, and a command palette (`Ctrl/Cmd+K`) for instant navigation.
+27 tools that run entirely in your browser — no data leaves your machine (except QR generation, which uses an external API). Two languages (EN/IT), theme switcher (light/dark/system), and a command palette (`Ctrl/Cmd+K`) for instant navigation.
 
 ## Tools
 
@@ -30,7 +30,7 @@ A modular, type-safe collection of 27 browser-based developer tools. Built with 
 |---|---|
 | Meta-framework | [Astro](https://astro.build/) 6 — static site generation, per-page code splitting |
 | UI framework | [Solid.js](https://www.solidjs.com/) — fine-grained reactivity, zero virtual DOM |
-| Styling | [Tailwind CSS](https://tailwindcss.com/) 4 — `@theme` design tokens, `prefers-color-scheme` |
+| Styling | [Tailwind CSS](https://tailwindcss.com/) 4 — `@theme` design tokens, theme switcher (light/dark/system) |
 | Type safety | TypeScript strict — `noUncheckedIndexedAccess`, zero `any` |
 | i18n | Type-safe JSON messages, compile-time key validation |
 | Search | [Fuse.js](https://www.fusejs.io/) — fuzzy search in command palette |
@@ -160,7 +160,7 @@ The tool automatically gets a page at `/{lang}/tools/my-tool` and appears in the
 
 ### Design Tokens
 
-Colors are defined as CSS custom properties in `src/styles/global.css` via Tailwind 4's `@theme` directive. Dark mode uses `@media (prefers-color-scheme: dark)` — no toggle, no JS, follows the device setting.
+Colors are defined as CSS custom properties in `src/styles/global.css` via Tailwind 4's `@theme` directive. Dark mode is controlled via a `data-theme` attribute on `<html>`. Users can switch between light, dark, and system (follows device setting) via the theme toggle button. The preference is persisted in `localStorage`.
 
 ## Privacy
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,7 +146,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2202,7 +2201,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2642,7 +2640,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5387,7 +5384,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5453,7 +5449,6 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.1.tgz",
       "integrity": "sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -5564,7 +5559,6 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz",
       "integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.5.0",
@@ -5799,7 +5793,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6159,7 +6152,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6278,7 +6270,6 @@
       "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.0",
         "@vitest/mocker": "4.1.0",

--- a/src/components/HomeCatalog.astro
+++ b/src/components/HomeCatalog.astro
@@ -52,6 +52,27 @@ const categoryAccents: Record<string, string> = {
           <span>⌘</span>K
         </kbd>
       </button>
+      <!-- Theme toggle -->
+      <button
+        type="button"
+        id="theme-toggle"
+        class="rounded-lg border border-border px-2.5 py-1.5 text-text-secondary transition-colors hover:bg-surface-raised hover:text-accent cursor-pointer"
+        aria-label={t(lang, 'app_themeToggleAria')}
+        title={t(lang, 'app_themeToggleAria')}
+      >
+        <!-- Sun icon (shown in dark mode) -->
+        <svg id="theme-icon-light" class="h-4 w-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+        </svg>
+        <!-- Moon icon (shown in light mode) -->
+        <svg id="theme-icon-dark" class="h-4 w-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+        </svg>
+        <!-- Monitor icon (shown in system mode) -->
+        <svg id="theme-icon-system" class="h-4 w-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+        </svg>
+      </button>
       <a
         href={`/${altLang}/`}
         class="rounded-lg border border-border px-2.5 py-1.5 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-raised hover:text-accent"
@@ -154,10 +175,11 @@ const categoryAccents: Record<string, string> = {
     <a href="https://github.com/amargiovanni/tools-collection" class="text-text-secondary hover:text-accent transition-colors">
       {t(lang, 'home_footerGithub')}
     </a>
+    &middot; <span class="text-text-muted">v1.0.0</span>
   </footer>
 </div>
 
-<!-- Trigger command palette from search button -->
+<!-- Trigger command palette from search button + theme toggle -->
 <script>
   function initHomeSearch() {
     const btn = document.getElementById('home-search-trigger')
@@ -167,6 +189,68 @@ const categoryAccents: Record<string, string> = {
       })
     }
   }
+
+  function initThemeToggle() {
+    const btn = document.getElementById('theme-toggle')
+    if (!btn) return
+
+    function getStoredPreference(): string {
+      return localStorage.getItem('theme') || 'system'
+    }
+
+    function updateIcon(pref: string) {
+      const iconLight = document.getElementById('theme-icon-light')
+      const iconDark = document.getElementById('theme-icon-dark')
+      const iconSystem = document.getElementById('theme-icon-system')
+      if (!iconLight || !iconDark || !iconSystem) return
+      iconLight.classList.add('hidden')
+      iconDark.classList.add('hidden')
+      iconSystem.classList.add('hidden')
+      if (pref === 'light') iconDark.classList.remove('hidden')
+      else if (pref === 'dark') iconLight.classList.remove('hidden')
+      else iconSystem.classList.remove('hidden')
+    }
+
+    function applyTheme(pref: string) {
+      let effective = pref
+      if (pref === 'system') {
+        effective = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+      }
+      document.documentElement.setAttribute('data-theme', effective)
+    }
+
+    function cyclePref(current: string): string {
+      if (current === 'system') return 'light'
+      if (current === 'light') return 'dark'
+      return 'system'
+    }
+
+    let pref = getStoredPreference()
+    updateIcon(pref)
+
+    btn.addEventListener('click', () => {
+      pref = cyclePref(pref)
+      if (pref === 'system') {
+        localStorage.removeItem('theme')
+      } else {
+        localStorage.setItem('theme', pref)
+      }
+      applyTheme(pref)
+      updateIcon(pref)
+    })
+
+    // Listen for system theme changes when in "system" mode
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+      if (getStoredPreference() === 'system') {
+        applyTheme('system')
+      }
+    })
+  }
+
   initHomeSearch()
-  document.addEventListener('astro:page-load', initHomeSearch)
+  initThemeToggle()
+  document.addEventListener('astro:page-load', () => {
+    initHomeSearch()
+    initThemeToggle()
+  })
 </script>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -6,6 +6,10 @@
   "app_searchPlaceholder": "Search tools...",
   "app_switchLanguageAria": "Switch language",
   "app_backHomeAria": "Back to home",
+  "app_themeLight": "Light",
+  "app_themeDark": "Dark",
+  "app_themeSystem": "System",
+  "app_themeToggleAria": "Toggle theme",
 
   "home_eyebrow": "Collection",
   "home_title": "Online Tools for Daily Work",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -6,6 +6,10 @@
   "app_searchPlaceholder": "Cerca strumenti...",
   "app_switchLanguageAria": "Cambia lingua",
   "app_backHomeAria": "Torna alla home",
+  "app_themeLight": "Chiaro",
+  "app_themeDark": "Scuro",
+  "app_themeSystem": "Sistema",
+  "app_themeToggleAria": "Cambia tema",
 
   "home_eyebrow": "Collezione",
   "home_title": "Strumenti Online per il Lavoro di Tutti i Giorni",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -31,6 +31,17 @@ const altUrl = new URL(altPath, Astro.site ?? 'https://tools.example.com').href
     <link rel="alternate" hreflang={lang} href={canonicalUrl} />
     <link rel="alternate" hreflang={altLang} href={altUrl} />
     <ClientRouter />
+    <!-- Theme: apply before paint to avoid flash -->
+    <script is:inline>
+      ;(function () {
+        var stored = localStorage.getItem('theme')
+        var theme = stored === 'light' || stored === 'dark' ? stored : null
+        if (!theme) {
+          theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+        }
+        document.documentElement.setAttribute('data-theme', theme)
+      })()
+    </script>
     <!-- Legacy hash redirect: #json-formatter → /en/tools/json-formatter -->
     <script is:inline>
       ;(function () {

--- a/src/layouts/ToolLayout.astro
+++ b/src/layouts/ToolLayout.astro
@@ -59,6 +59,24 @@ const currentPath = Astro.url.pathname
           <kbd class="hidden sm:inline-flex items-center gap-1 rounded border border-border bg-surface px-2 py-0.5 text-xs text-text-muted">
             <span>⌘</span>K
           </kbd>
+          <!-- Theme toggle -->
+          <button
+            type="button"
+            id="theme-toggle"
+            class="rounded-lg px-2 py-1 text-text-secondary transition-colors hover:bg-surface-raised hover:text-accent cursor-pointer"
+            aria-label={t(lang, 'app_themeToggleAria')}
+            title={t(lang, 'app_themeToggleAria')}
+          >
+            <svg id="theme-icon-light" class="h-4 w-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+            </svg>
+            <svg id="theme-icon-dark" class="h-4 w-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+            </svg>
+            <svg id="theme-icon-system" class="h-4 w-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+            </svg>
+          </button>
           <!-- Language switcher -->
           <a
             href={`/${altLang}/tools/${tool.id}`}
@@ -118,6 +136,61 @@ const currentPath = Astro.url.pathname
       // Focus tool heading on navigation
       const heading = document.getElementById('tool-heading')
       if (heading) heading.focus()
+
+      // Theme toggle
+      const themeBtn = document.getElementById('theme-toggle')
+      if (themeBtn) {
+        function getStoredPreference(): string {
+          return localStorage.getItem('theme') || 'system'
+        }
+
+        function updateIcon(pref: string) {
+          const iconLight = document.getElementById('theme-icon-light')
+          const iconDark = document.getElementById('theme-icon-dark')
+          const iconSystem = document.getElementById('theme-icon-system')
+          if (!iconLight || !iconDark || !iconSystem) return
+          iconLight.classList.add('hidden')
+          iconDark.classList.add('hidden')
+          iconSystem.classList.add('hidden')
+          if (pref === 'light') iconDark.classList.remove('hidden')
+          else if (pref === 'dark') iconLight.classList.remove('hidden')
+          else iconSystem.classList.remove('hidden')
+        }
+
+        function applyTheme(pref: string) {
+          let effective = pref
+          if (pref === 'system') {
+            effective = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+          }
+          document.documentElement.setAttribute('data-theme', effective)
+        }
+
+        function cyclePref(current: string): string {
+          if (current === 'system') return 'light'
+          if (current === 'light') return 'dark'
+          return 'system'
+        }
+
+        let pref = getStoredPreference()
+        updateIcon(pref)
+
+        themeBtn.addEventListener('click', () => {
+          pref = cyclePref(pref)
+          if (pref === 'system') {
+            localStorage.removeItem('theme')
+          } else {
+            localStorage.setItem('theme', pref)
+          }
+          applyTheme(pref)
+          updateIcon(pref)
+        })
+
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+          if (getStoredPreference() === 'system') {
+            applyTheme('system')
+          }
+        })
+      }
     }
 
     // Run on initial load and after every client-side navigation

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+
 @theme {
   --color-surface: #faf9f7;
   --color-surface-raised: #ffffff;
@@ -21,25 +23,23 @@
   --font-mono: 'Geist Mono', ui-monospace, monospace;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-surface: #0f172a;
-    --color-surface-raised: #1e293b;
-    --color-text-primary: #f1f5f9;
-    --color-text-secondary: #94a3b8;
-    --color-text-muted: #64748b;
-    --color-accent: #2dd4bf;
-    --color-accent-hover: #5eead4;
-    --color-accent-light: #042f2e;
-    --color-border: #334155;
-    --color-border-focus: #2dd4bf;
-    --color-success: #4ade80;
-    --color-success-light: #052e16;
-    --color-error: #f87171;
-    --color-error-light: #450a0a;
-    --color-warning: #fbbf24;
-    --color-warning-light: #451a03;
-  }
+[data-theme="dark"] {
+  --color-surface: #0f172a;
+  --color-surface-raised: #1e293b;
+  --color-text-primary: #f1f5f9;
+  --color-text-secondary: #94a3b8;
+  --color-text-muted: #64748b;
+  --color-accent: #2dd4bf;
+  --color-accent-hover: #5eead4;
+  --color-accent-light: #042f2e;
+  --color-border: #334155;
+  --color-border-focus: #2dd4bf;
+  --color-success: #4ade80;
+  --color-success-light: #052e16;
+  --color-error: #f87171;
+  --color-error-light: #450a0a;
+  --color-warning: #fbbf24;
+  --color-warning-light: #451a03;
 }
 
 html {

--- a/tests/build/theme-toggle.test.ts
+++ b/tests/build/theme-toggle.test.ts
@@ -4,20 +4,24 @@ import { join } from 'path'
 
 const ROOT = process.cwd()
 
-describe('dark mode via prefers-color-scheme', () => {
-  it('global CSS uses prefers-color-scheme media query, not .dark class', () => {
+describe('theme toggle', () => {
+  it('global CSS uses data-theme attribute for dark mode', () => {
     const css = readFileSync(join(ROOT, 'src', 'styles', 'global.css'), 'utf-8')
-    expect(css).toContain('prefers-color-scheme: dark')
-    expect(css).not.toContain('.dark {')
+    expect(css).toContain('[data-theme="dark"]')
   })
 
-  it('ToolLayout does not contain a theme-toggle button', () => {
+  it('ToolLayout contains a theme-toggle button', () => {
     const layout = readFileSync(join(ROOT, 'src', 'layouts', 'ToolLayout.astro'), 'utf-8')
-    expect(layout).not.toContain('id="theme-toggle"')
+    expect(layout).toContain('id="theme-toggle"')
   })
 
-  it('BaseLayout does not contain flash prevention script', () => {
+  it('BaseLayout contains theme initialization script', () => {
     const layout = readFileSync(join(ROOT, 'src', 'layouts', 'BaseLayout.astro'), 'utf-8')
-    expect(layout).not.toContain("classList.add('dark')")
+    expect(layout).toContain('data-theme')
+  })
+
+  it('HomeCatalog contains a theme-toggle button', () => {
+    const catalog = readFileSync(join(ROOT, 'src', 'components', 'HomeCatalog.astro'), 'utf-8')
+    expect(catalog).toContain('id="theme-toggle"')
   })
 })


### PR DESCRIPTION
Add a theme switcher button to both the home page and tool page headers,
allowing users to cycle between light, dark, and system (follows OS
preference) modes. Theme preference is persisted in localStorage with
flash-free initialization via an inline script in BaseLayout.

Also display the app version (v1.0.0) in the home page footer for
visibility.

https://claude.ai/code/session_017bXcEph1T74AoKDwwShGyV