### PR TITLE
Fix theme reset when switching language via client-side navigation

### DIFF
--- a/src/components/HomeCatalog.astro
+++ b/src/components/HomeCatalog.astro
@@ -226,6 +226,7 @@ const categoryAccents: Record<string, string> = {
     }
 
     let pref = getStoredPreference()
+    applyTheme(pref)
     updateIcon(pref)
 
     btn.addEventListener('click', () => {

--- a/src/layouts/ToolLayout.astro
+++ b/src/layouts/ToolLayout.astro
@@ -172,6 +172,7 @@ const currentPath = Astro.url.pathname
         }
 
         let pref = getStoredPreference()
+        applyTheme(pref)
         updateIcon(pref)
 
         themeBtn.addEventListener('click', () => {


### PR DESCRIPTION
Astro's ClientRouter strips the data-theme attribute from <html> during
page transitions, and the is:inline head script doesn't re-run. The
initThemeToggle() function was only calling updateIcon() on init but
never applyTheme(), so the theme was lost after navigation.

https://claude.ai/code/session_01KsfmDraTQjvJugVuURVatB