### PR TITLE
Add homepage back-to-top button

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -33,4 +33,21 @@ test.describe('Navigation', () => {
     await page.keyboard.press('Meta+k')
     await expect(page.getByPlaceholder('Search tools...')).toBeVisible()
   })
+
+  test('back-to-top button appears after scrolling and returns to top', async ({ page }) => {
+    await page.goto('/en/', { waitUntil: 'networkidle' })
+
+    const backToTop = page.locator('#home-back-to-top')
+    await expect(backToTop).toHaveAttribute('aria-hidden', 'true')
+
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+    await page.waitForFunction(() => {
+      const btn = document.getElementById('home-back-to-top')
+      return btn?.getAttribute('aria-hidden') === 'false'
+    })
+
+    await expect(backToTop).toBeVisible()
+    await backToTop.click()
+    await page.waitForFunction(() => window.scrollY < 20)
+  })
 })

--- a/src/components/HomeCatalog.astro
+++ b/src/components/HomeCatalog.astro
@@ -226,6 +226,20 @@ const categoryAccents: Record<string, string> = {
     </a>
     &middot; <span class="text-text-muted">v{appVersion}</span>
   </footer>
+
+  <button
+    type="button"
+    id="home-back-to-top"
+    class="fixed bottom-4 right-4 z-40 inline-flex h-12 w-12 items-center justify-center rounded-full border border-border bg-surface-raised/95 text-accent opacity-0 shadow-lg shadow-black/10 backdrop-blur transition-all duration-300 translate-y-2 pointer-events-none hover:-translate-y-0.5 hover:scale-105 hover:text-accent-hover sm:bottom-6 sm:right-6"
+    aria-label={t(lang, 'home_backToTopAria')}
+    title={t(lang, 'home_backToTopAria')}
+    aria-hidden="true"
+    tabindex="-1"
+  >
+    <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19V5m0 0l-6 6m6-6 6 6" />
+    </svg>
+  </button>
 </div>
 
 <!-- Trigger command palette from search button + theme toggle -->
@@ -297,11 +311,53 @@ const categoryAccents: Record<string, string> = {
     })
   }
 
+  function initBackToTop() {
+    const btn = document.getElementById('home-back-to-top')
+    if (!btn || btn.dataset.bound === 'true') return
+    btn.dataset.bound = 'true'
+
+    const globalWindow = window as Window & { __homeBackToTopAbort?: AbortController }
+    globalWindow.__homeBackToTopAbort?.abort()
+    const controller = new AbortController()
+    globalWindow.__homeBackToTopAbort = controller
+
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    const threshold = 320
+
+    function setVisible(visible: boolean) {
+      btn.classList.toggle('opacity-0', !visible)
+      btn.classList.toggle('translate-y-2', !visible)
+      btn.classList.toggle('pointer-events-none', !visible)
+      btn.tabIndex = visible ? 0 : -1
+      btn.setAttribute('aria-hidden', visible ? 'false' : 'true')
+    }
+
+    function updateVisibility() {
+      setVisible(window.scrollY > threshold)
+    }
+
+    function onScroll() {
+      window.requestAnimationFrame(updateVisibility)
+    }
+
+    btn.addEventListener('click', () => {
+      window.scrollTo({
+        top: 0,
+        behavior: reducedMotion ? 'auto' : 'smooth',
+      })
+    }, { signal: controller.signal })
+
+    window.addEventListener('scroll', onScroll, { passive: true, signal: controller.signal })
+    updateVisibility()
+  }
+
   initHomeSearch()
   initThemeToggle()
+  initBackToTop()
   document.addEventListener('astro:page-load', () => {
     initHomeSearch()
     initThemeToggle()
+    initBackToTop()
   })
 </script>
 

--- a/src/components/HomeCatalog.astro
+++ b/src/components/HomeCatalog.astro
@@ -321,10 +321,14 @@ const categoryAccents: Record<string, string> = {
     const controller = new AbortController()
     globalWindow.__homeBackToTopAbort = controller
 
-    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
     const threshold = 320
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    let isVisible = false
+    let ticking = false
 
     function setVisible(visible: boolean) {
+      if (visible === isVisible) return
+      isVisible = visible
       btn.classList.toggle('opacity-0', !visible)
       btn.classList.toggle('translate-y-2', !visible)
       btn.classList.toggle('pointer-events-none', !visible)
@@ -337,7 +341,16 @@ const categoryAccents: Record<string, string> = {
     }
 
     function onScroll() {
-      window.requestAnimationFrame(updateVisibility)
+      if (!btn.isConnected) {
+        controller.abort()
+        return
+      }
+      if (ticking) return
+      ticking = true
+      window.requestAnimationFrame(() => {
+        updateVisibility()
+        ticking = false
+      })
     }
 
     btn.addEventListener('click', () => {

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -14,6 +14,7 @@
   "home_title": "Online-Werkzeuge für den Arbeitsalltag",
   "home_description": "Wähle ein Werkzeug aus dem Katalog oder drücke Strg+K zum Suchen.",
   "home_openTool": "Werkzeug öffnen",
+  "home_backToTopAria": "Nach oben",
   "home_footerName": "Tools Collection",
   "home_footerGithub": "GitHub",
   "categories_textProcessing": "Textverarbeitung",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -14,6 +14,7 @@
   "home_title": "Online Tools for Daily Work",
   "home_description": "Pick a tool from the catalog below or press Ctrl+K to search.",
   "home_openTool": "Open tool",
+  "home_backToTopAria": "Back to top",
   "home_footerName": "Tools Collection",
   "home_footerGithub": "GitHub",
   "categories_textProcessing": "Text Processing",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -14,6 +14,7 @@
   "home_title": "Herramientas en línea para el trabajo diario",
   "home_description": "Elige una herramienta del catálogo o pulsa Ctrl+K para buscar.",
   "home_openTool": "Abrir herramienta",
+  "home_backToTopAria": "Volver arriba",
   "home_footerName": "Tools Collection",
   "home_footerGithub": "GitHub",
   "categories_textProcessing": "Procesamiento de texto",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -14,6 +14,7 @@
   "home_title": "Outils en ligne pour le travail quotidien",
   "home_description": "Choisissez un outil dans le catalogue ci-dessous ou appuyez sur Ctrl+K pour rechercher.",
   "home_openTool": "Ouvrir l'outil",
+  "home_backToTopAria": "Retour en haut",
   "home_footerName": "Tools Collection",
   "home_footerGithub": "GitHub",
   "categories_textProcessing": "Traitement de texte",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -14,6 +14,7 @@
   "home_title": "Strumenti Online per il Lavoro di Tutti i Giorni",
   "home_description": "Scegli uno strumento dal catalogo qui sotto o premi Ctrl+K per cercare.",
   "home_openTool": "Apri tool",
+  "home_backToTopAria": "Torna in cima",
   "home_footerName": "Tools Collection",
   "home_footerGithub": "GitHub",
   "categories_textProcessing": "Elaborazione Testo",


### PR DESCRIPTION
Adds a floating back-to-top control on the homepage that appears after scrolling and returns to the top with smooth scrolling, with reduced-motion fallback. Also adds localized aria labels and an e2e regression test.