### PR TITLE
feat(text): add slug generator tool

### DIFF
--- a/src/components/tools/SlugGenerator.tsx
+++ b/src/components/tools/SlugGenerator.tsx
@@ -28,7 +28,7 @@ export default function SlugGenerator(props: Props) {
     const saved = await decodeState(new URLSearchParams(location.search).get('s'))
     if (saved) {
       if (typeof saved['input'] === 'string') setInput(saved['input'])
-      if (typeof saved['separator'] === 'string') setSeparator(saved['separator'] as SeparatorType)
+      if (saved['separator'] && ['hyphen', 'underscore', 'dot'].includes(saved['separator'])) setSeparator(saved['separator'] as SeparatorType)
       if (typeof saved['lowercase'] === 'boolean') setLowercase(saved['lowercase'])
       if (typeof saved['maxLength'] === 'number') setMaxLength(saved['maxLength'])
       if (typeof saved['transliterate'] === 'boolean') setTransliterate(saved['transliterate'])

--- a/src/components/tools/SlugGenerator.tsx
+++ b/src/components/tools/SlugGenerator.tsx
@@ -1,5 +1,5 @@
-import { createSignal, createEffect, onMount, onCleanup } from 'solid-js'
-import { decodeState, TOOL_STATE_REQUEST, TOOL_STATE_RESPONSE } from '../../lib/share'
+import { createSignal, createEffect } from 'solid-js'
+import { useToolState } from '../../lib/useToolState'
 import { TextArea } from '../ui/TextArea'
 import { Select } from '../ui/Select'
 import { Checkbox } from '../ui/Checkbox'
@@ -24,30 +24,23 @@ export default function SlugGenerator(props: Props) {
   const [output, setOutput] = createSignal('')
   const [error, setError] = createSignal<string | null>(null)
 
-  onMount(async () => {
-    const saved = await decodeState(new URLSearchParams(location.search).get('s'))
-    if (saved) {
+  useToolState({
+    onRestore(saved) {
       if (typeof saved['input'] === 'string') setInput(saved['input'])
-      if (saved['separator'] && ['hyphen', 'underscore', 'dot'].includes(saved['separator'])) setSeparator(saved['separator'] as SeparatorType)
+      if (typeof saved['separator'] === 'string' && ['hyphen', 'underscore', 'dot'].includes(saved['separator'])) {
+        setSeparator(saved['separator'] as SeparatorType)
+      }
       if (typeof saved['lowercase'] === 'boolean') setLowercase(saved['lowercase'])
       if (typeof saved['maxLength'] === 'number') setMaxLength(saved['maxLength'])
       if (typeof saved['transliterate'] === 'boolean') setTransliterate(saved['transliterate'])
-    }
-    const handler = () => {
-      window.dispatchEvent(new CustomEvent(TOOL_STATE_RESPONSE, {
-        detail: {
-          state: {
-            input: input(),
-            separator: separator(),
-            lowercase: lowercase(),
-            maxLength: maxLength(),
-            transliterate: transliterate(),
-          },
-        },
-      }))
-    }
-    window.addEventListener(TOOL_STATE_REQUEST, handler)
-    onCleanup(() => window.removeEventListener(TOOL_STATE_REQUEST, handler))
+    },
+    getState: () => ({
+      input: input(),
+      separator: separator(),
+      lowercase: lowercase(),
+      maxLength: maxLength(),
+      transliterate: transliterate(),
+    }),
   })
 
   const separatorOptions = () => [

--- a/src/components/tools/SlugGenerator.tsx
+++ b/src/components/tools/SlugGenerator.tsx
@@ -1,0 +1,123 @@
+import { createSignal, createEffect, onMount, onCleanup } from 'solid-js'
+import { decodeState, TOOL_STATE_REQUEST, TOOL_STATE_RESPONSE } from '../../lib/share'
+import { TextArea } from '../ui/TextArea'
+import { Select } from '../ui/Select'
+import { Checkbox } from '../ui/Checkbox'
+import { Input } from '../ui/Input'
+import { OutputPanel } from '../ui/OutputPanel'
+import { StatusMessage } from '../ui/StatusMessage'
+import { generateSlug } from '../../tools/slug-generator'
+import type { SeparatorType } from '../../tools/slug-generator'
+import { t, translateError } from '../../i18n'
+import type { Language } from '../../i18n'
+
+interface Props {
+  lang: Language
+}
+
+export default function SlugGenerator(props: Props) {
+  const [input, setInput] = createSignal('')
+  const [separator, setSeparator] = createSignal<SeparatorType>('hyphen')
+  const [lowercase, setLowercase] = createSignal(true)
+  const [maxLength, setMaxLength] = createSignal(0)
+  const [transliterate, setTransliterate] = createSignal(true)
+  const [output, setOutput] = createSignal('')
+  const [error, setError] = createSignal<string | null>(null)
+
+  onMount(async () => {
+    const saved = await decodeState(new URLSearchParams(location.search).get('s'))
+    if (saved) {
+      if (typeof saved['input'] === 'string') setInput(saved['input'])
+      if (typeof saved['separator'] === 'string') setSeparator(saved['separator'] as SeparatorType)
+      if (typeof saved['lowercase'] === 'boolean') setLowercase(saved['lowercase'])
+      if (typeof saved['maxLength'] === 'number') setMaxLength(saved['maxLength'])
+      if (typeof saved['transliterate'] === 'boolean') setTransliterate(saved['transliterate'])
+    }
+    const handler = () => {
+      window.dispatchEvent(new CustomEvent(TOOL_STATE_RESPONSE, {
+        detail: {
+          state: {
+            input: input(),
+            separator: separator(),
+            lowercase: lowercase(),
+            maxLength: maxLength(),
+            transliterate: transliterate(),
+          },
+        },
+      }))
+    }
+    window.addEventListener(TOOL_STATE_REQUEST, handler)
+    onCleanup(() => window.removeEventListener(TOOL_STATE_REQUEST, handler))
+  })
+
+  const separatorOptions = () => [
+    { value: 'hyphen', label: t(props.lang, 'tools_slugGenerator_separatorHyphen') },
+    { value: 'underscore', label: t(props.lang, 'tools_slugGenerator_separatorUnderscore') },
+    { value: 'dot', label: t(props.lang, 'tools_slugGenerator_separatorDot') },
+  ]
+
+  // Live preview: regenerate slug whenever any input or option changes
+  createEffect(() => {
+    const text = input()
+    if (text === '') {
+      setOutput('')
+      setError(null)
+      return
+    }
+    const result = generateSlug(text, {
+      separator: separator(),
+      lowercase: lowercase(),
+      maxLength: maxLength(),
+      transliterate: transliterate(),
+    })
+    if (result.ok) {
+      setOutput(result.value)
+      setError(null)
+    } else {
+      setError(translateError(props.lang, result.error))
+      setOutput('')
+    }
+  })
+
+  return (
+    <div class="flex flex-col gap-4">
+      <TextArea
+        label={t(props.lang, 'tools_slugGenerator_inputLabel')}
+        placeholder={t(props.lang, 'tools_slugGenerator_placeholder')}
+        value={input()}
+        onInput={(e) => setInput(e.currentTarget.value)}
+        rows={3}
+      />
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <Select
+          label={t(props.lang, 'tools_slugGenerator_separatorLabel')}
+          options={separatorOptions()}
+          value={separator()}
+          onChange={(e) => setSeparator(e.currentTarget.value as SeparatorType)}
+        />
+        <Input
+          type="number"
+          label={t(props.lang, 'tools_slugGenerator_maxLengthLabel')}
+          placeholder={t(props.lang, 'tools_slugGenerator_maxLengthPlaceholder')}
+          value={maxLength()}
+          min={0}
+          onInput={(e) => setMaxLength(parseInt(e.currentTarget.value, 10) || 0)}
+        />
+      </div>
+      <div class="flex flex-wrap gap-4">
+        <Checkbox
+          label={t(props.lang, 'tools_slugGenerator_lowercase')}
+          checked={lowercase()}
+          onChange={(e) => setLowercase(e.currentTarget.checked)}
+        />
+        <Checkbox
+          label={t(props.lang, 'tools_slugGenerator_transliterate')}
+          checked={transliterate()}
+          onChange={(e) => setTransliterate(e.currentTarget.checked)}
+        />
+      </div>
+      {error() && <StatusMessage type="error" message={error()!} />}
+      <OutputPanel value={output()} label={t(props.lang, 'common_result')} />
+    </div>
+  )
+}

--- a/src/config/tool-components.ts
+++ b/src/config/tool-components.ts
@@ -47,4 +47,5 @@ export const toolComponents: Record<string, ToolComponent> = {
   'uuid-generator': lazy(() => import('../components/tools/UuidGenerator')),
   'number-base-converter': lazy(() => import('../components/tools/NumberBaseConverter')),
   'csv-viewer': lazy(() => import('../components/tools/CsvViewer')),
+  'slug-generator': lazy(() => import('../components/tools/SlugGenerator')),
 }

--- a/src/config/tools.ts
+++ b/src/config/tools.ts
@@ -63,6 +63,13 @@ export const toolRegistry: readonly ToolMeta[] = [
     keywords: ['remove', 'filter', 'containing', 'delete', 'lines', 'words'],
     path: '/tools/remove-lines-containing',
   },
+  {
+    id: 'slug-generator',
+    category: 'text-processing',
+    icon: '🔗',
+    keywords: ['slug', 'url', 'friendly', 'permalink', 'seo', 'slugify', 'generate'],
+    path: '/tools/slug-generator',
+  },
 
   // Generators
   {

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -431,6 +431,7 @@
   "errors_QR_UNSUPPORTED": "BarcodeDetector wird in diesem Browser nicht unterstützt",
   "errors_QR_NOT_FOUND": "Kein QR-Code im Bild erkannt",
   "errors_UNIQUE_IMPOSSIBLE": "Mit den gegebenen Einschränkungen können nicht genügend eindeutige Werte generiert werden",
+  "errors_EMPTY_RESULT": "Die Eingabe erzeugt einen leeren Slug",
   "favorites_title": "Favoriten",
   "favorites_add": "Zu Favoriten hinzufügen",
   "favorites_remove": "Aus Favoriten entfernen",
@@ -474,5 +475,17 @@
   "csv_placeholder": "CSV-Daten hier einfügen...",
   "csv_rowCount": "{n} Zeilen",
   "csv_noData": "Keine Daten anzuzeigen",
-  "csv_exportJson": "Als JSON exportieren"
+  "csv_exportJson": "Als JSON exportieren",
+  "tools_slugGenerator_name": "Slug-Generator",
+  "tools_slugGenerator_description": "Text in URL-freundliche Slugs umwandeln",
+  "tools_slugGenerator_inputLabel": "Text zum Umwandeln:",
+  "tools_slugGenerator_placeholder": "Geben Sie Ihren Titel oder Text ein...",
+  "tools_slugGenerator_separatorLabel": "Trennzeichen:",
+  "tools_slugGenerator_separatorHyphen": "Bindestrich (-)",
+  "tools_slugGenerator_separatorUnderscore": "Unterstrich (_)",
+  "tools_slugGenerator_separatorDot": "Punkt (.)",
+  "tools_slugGenerator_lowercase": "Kleinbuchstaben",
+  "tools_slugGenerator_transliterate": "Akzentzeichen transliterieren",
+  "tools_slugGenerator_maxLengthLabel": "Maximale Länge:",
+  "tools_slugGenerator_maxLengthPlaceholder": "0 = ohne Limit"
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -431,6 +431,7 @@
   "errors_QR_UNSUPPORTED": "BarcodeDetector not supported in this browser",
   "errors_QR_NOT_FOUND": "No QR code detected in the image",
   "errors_UNIQUE_IMPOSSIBLE": "Cannot generate enough unique values with the given constraints",
+  "errors_EMPTY_RESULT": "The input produces an empty slug",
   "favorites_title": "Favorites",
   "favorites_add": "Add to favorites",
   "favorites_remove": "Remove from favorites",
@@ -474,5 +475,17 @@
   "csv_placeholder": "Paste CSV data here...",
   "csv_rowCount": "{n} rows",
   "csv_noData": "No data to display",
-  "csv_exportJson": "Export as JSON"
+  "csv_exportJson": "Export as JSON",
+  "tools_slugGenerator_name": "Slug Generator",
+  "tools_slugGenerator_description": "Convert text into URL-friendly slugs",
+  "tools_slugGenerator_inputLabel": "Text to slugify:",
+  "tools_slugGenerator_placeholder": "Enter your title or text here...",
+  "tools_slugGenerator_separatorLabel": "Separator:",
+  "tools_slugGenerator_separatorHyphen": "Hyphen (-)",
+  "tools_slugGenerator_separatorUnderscore": "Underscore (_)",
+  "tools_slugGenerator_separatorDot": "Dot (.)",
+  "tools_slugGenerator_lowercase": "Lowercase",
+  "tools_slugGenerator_transliterate": "Transliterate accented characters",
+  "tools_slugGenerator_maxLengthLabel": "Max length:",
+  "tools_slugGenerator_maxLengthPlaceholder": "0 = no limit"
 }

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -431,6 +431,7 @@
   "errors_QR_UNSUPPORTED": "BarcodeDetector no es compatible con este navegador",
   "errors_QR_NOT_FOUND": "No se detectó ningún código QR en la imagen",
   "errors_UNIQUE_IMPOSSIBLE": "No se pueden generar suficientes valores únicos con las restricciones dadas",
+  "errors_EMPTY_RESULT": "El texto introducido produce un slug vacío",
   "favorites_title": "Favoritos",
   "favorites_add": "Agregar a favoritos",
   "favorites_remove": "Quitar de favoritos",
@@ -474,5 +475,17 @@
   "csv_placeholder": "Pega los datos CSV aquí...",
   "csv_rowCount": "{n} filas",
   "csv_noData": "No hay datos para mostrar",
-  "csv_exportJson": "Exportar como JSON"
+  "csv_exportJson": "Exportar como JSON",
+  "tools_slugGenerator_name": "Generador de Slug",
+  "tools_slugGenerator_description": "Convierte texto en slugs compatibles con URLs",
+  "tools_slugGenerator_inputLabel": "Texto a convertir en slug:",
+  "tools_slugGenerator_placeholder": "Introduce tu título o texto aquí...",
+  "tools_slugGenerator_separatorLabel": "Separador:",
+  "tools_slugGenerator_separatorHyphen": "Guión (-)",
+  "tools_slugGenerator_separatorUnderscore": "Guión bajo (_)",
+  "tools_slugGenerator_separatorDot": "Punto (.)",
+  "tools_slugGenerator_lowercase": "Minúsculas",
+  "tools_slugGenerator_transliterate": "Transliterar caracteres acentuados",
+  "tools_slugGenerator_maxLengthLabel": "Longitud máxima:",
+  "tools_slugGenerator_maxLengthPlaceholder": "0 = sin límite"
 }

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -431,6 +431,7 @@
   "errors_QR_UNSUPPORTED": "BarcodeDetector non pris en charge dans ce navigateur",
   "errors_QR_NOT_FOUND": "Aucun QR code détecté dans l'image",
   "errors_UNIQUE_IMPOSSIBLE": "Impossible de générer suffisamment de valeurs uniques avec les contraintes données",
+  "errors_EMPTY_RESULT": "Le texte saisi produit un slug vide",
   "favorites_title": "Favoris",
   "favorites_add": "Ajouter aux favoris",
   "favorites_remove": "Retirer des favoris",
@@ -474,5 +475,17 @@
   "csv_placeholder": "Collez les données CSV ici...",
   "csv_rowCount": "{n} lignes",
   "csv_noData": "Aucune donnée à afficher",
-  "csv_exportJson": "Exporter en JSON"
+  "csv_exportJson": "Exporter en JSON",
+  "tools_slugGenerator_name": "Générateur de Slug",
+  "tools_slugGenerator_description": "Convertir du texte en slugs compatibles URL",
+  "tools_slugGenerator_inputLabel": "Texte à convertir en slug :",
+  "tools_slugGenerator_placeholder": "Entrez votre titre ou texte ici...",
+  "tools_slugGenerator_separatorLabel": "Séparateur :",
+  "tools_slugGenerator_separatorHyphen": "Tiret (-)",
+  "tools_slugGenerator_separatorUnderscore": "Underscore (_)",
+  "tools_slugGenerator_separatorDot": "Point (.)",
+  "tools_slugGenerator_lowercase": "Minuscules",
+  "tools_slugGenerator_transliterate": "Translittérer les caractères accentués",
+  "tools_slugGenerator_maxLengthLabel": "Longueur maximale :",
+  "tools_slugGenerator_maxLengthPlaceholder": "0 = sans limite"
 }

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -431,6 +431,7 @@
   "errors_QR_UNSUPPORTED": "BarcodeDetector non supportato in questo browser",
   "errors_QR_NOT_FOUND": "Nessun QR code rilevato nell'immagine",
   "errors_UNIQUE_IMPOSSIBLE": "Impossibile generare abbastanza valori unici con i vincoli dati",
+  "errors_EMPTY_RESULT": "L'input produce uno slug vuoto",
   "favorites_title": "Preferiti",
   "favorites_add": "Aggiungi ai preferiti",
   "favorites_remove": "Rimuovi dai preferiti",
@@ -474,5 +475,17 @@
   "csv_placeholder": "Incolla i dati CSV qui...",
   "csv_rowCount": "{n} righe",
   "csv_noData": "Nessun dato da visualizzare",
-  "csv_exportJson": "Esporta come JSON"
+  "csv_exportJson": "Esporta come JSON",
+  "tools_slugGenerator_name": "Generatore di Slug",
+  "tools_slugGenerator_description": "Converti il testo in slug compatibili con gli URL",
+  "tools_slugGenerator_inputLabel": "Testo da trasformare in slug:",
+  "tools_slugGenerator_placeholder": "Inserisci il titolo o il testo qui...",
+  "tools_slugGenerator_separatorLabel": "Separatore:",
+  "tools_slugGenerator_separatorHyphen": "Trattino (-)",
+  "tools_slugGenerator_separatorUnderscore": "Underscore (_)",
+  "tools_slugGenerator_separatorDot": "Punto (.)",
+  "tools_slugGenerator_lowercase": "Minuscolo",
+  "tools_slugGenerator_transliterate": "Translittera caratteri accentati",
+  "tools_slugGenerator_maxLengthLabel": "Lunghezza massima:",
+  "tools_slugGenerator_maxLengthPlaceholder": "0 = nessun limite"
 }

--- a/src/tools/slug-generator.ts
+++ b/src/tools/slug-generator.ts
@@ -1,5 +1,6 @@
 import { ok, err } from '../lib/result'
 import type { Result } from '../lib/result'
+import { validateNonEmpty } from '../lib/validation'
 
 export type SeparatorType = 'hyphen' | 'underscore' | 'dot'
 
@@ -83,13 +84,12 @@ function stripDiacritics(input: string): string {
 }
 
 export function generateSlug(input: string, options: SlugOptions = defaultSlugOptions): Result<string> {
-  if (input === '') {
-    return err('EMPTY_INPUT', 'Please enter some input')
-  }
+  const validated = validateNonEmpty(input)
+  if (!validated.ok) return validated
 
   const sep = SEPARATOR_CHARS[options.separator]
 
-  let slug = input
+  let slug = validated.value
 
   // Step 1: transliterate known characters (before NFD to handle multi-char mappings like ss, ae)
   if (options.transliterate) {

--- a/src/tools/slug-generator.ts
+++ b/src/tools/slug-generator.ts
@@ -105,11 +105,11 @@ export function generateSlug(input: string, options: SlugOptions = defaultSlugOp
   }
 
   // Step 4: replace non-alphanumeric characters (except the separator) with the separator
-  const safePattern = new RegExp(`[^a-zA-Z0-9${sep === '.' ? '\\.' : sep}]+`, 'g')
+  const escapedSep = sep.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const safePattern = new RegExp(`[^a-zA-Z0-9${escapedSep}]+`, 'g')
   slug = slug.replace(safePattern, sep)
 
   // Step 5: collapse consecutive separators
-  const escapedSep = sep === '.' ? '\\.' : sep
   slug = slug.replace(new RegExp(`${escapedSep}{2,}`, 'g'), sep)
 
   // Step 6: trim leading/trailing separators

--- a/src/tools/slug-generator.ts
+++ b/src/tools/slug-generator.ts
@@ -1,0 +1,135 @@
+import { ok, err } from '../lib/result'
+import type { Result } from '../lib/result'
+
+export type SeparatorType = 'hyphen' | 'underscore' | 'dot'
+
+export interface SlugOptions {
+  readonly separator: SeparatorType
+  readonly lowercase: boolean
+  readonly maxLength: number
+  readonly transliterate: boolean
+}
+
+const TRANSLITERATION_MAP: Record<string, string> = {
+  // Latin extended - lowercase
+  '\u00e0': 'a', '\u00e1': 'a', '\u00e2': 'a', '\u00e3': 'a', '\u00e4': 'a', '\u00e5': 'a',
+  '\u00e8': 'e', '\u00e9': 'e', '\u00ea': 'e', '\u00eb': 'e',
+  '\u00ec': 'i', '\u00ed': 'i', '\u00ee': 'i', '\u00ef': 'i',
+  '\u00f2': 'o', '\u00f3': 'o', '\u00f4': 'o', '\u00f5': 'o', '\u00f6': 'o', '\u00f8': 'o',
+  '\u00f9': 'u', '\u00fa': 'u', '\u00fb': 'u', '\u00fc': 'u',
+  '\u00f1': 'n',
+  '\u00e7': 'c',
+  '\u00df': 'ss',
+  '\u00e6': 'ae',
+  '\u0153': 'oe',
+  '\u00f0': 'd',
+  '\u00fe': 'th',
+  '\u0142': 'l',
+  '\u017e': 'z', '\u017a': 'z', '\u017c': 'z',
+  '\u0161': 's', '\u015b': 's', '\u015f': 's',
+  '\u010d': 'c', '\u0107': 'c',
+  '\u0159': 'r',
+  '\u010f': 'd',
+  '\u0165': 't',
+  '\u0148': 'n', '\u0144': 'n',
+  '\u01b0': 'u',
+  '\u0111': 'd',
+  // Latin extended - uppercase
+  '\u00c0': 'A', '\u00c1': 'A', '\u00c2': 'A', '\u00c3': 'A', '\u00c4': 'A', '\u00c5': 'A',
+  '\u00c8': 'E', '\u00c9': 'E', '\u00ca': 'E', '\u00cb': 'E',
+  '\u00cc': 'I', '\u00cd': 'I', '\u00ce': 'I', '\u00cf': 'I',
+  '\u00d2': 'O', '\u00d3': 'O', '\u00d4': 'O', '\u00d5': 'O', '\u00d6': 'O', '\u00d8': 'O',
+  '\u00d9': 'U', '\u00da': 'U', '\u00db': 'U', '\u00dc': 'U',
+  '\u00d1': 'N',
+  '\u00c7': 'C',
+  '\u00c6': 'AE',
+  '\u0152': 'OE',
+  '\u00d0': 'D',
+  '\u00de': 'TH',
+  '\u0141': 'L',
+  '\u017d': 'Z', '\u0179': 'Z', '\u017b': 'Z',
+  '\u0160': 'S', '\u015a': 'S', '\u015e': 'S',
+  '\u010c': 'C', '\u0106': 'C',
+  '\u0158': 'R',
+  '\u010e': 'D',
+  '\u0164': 'T',
+  '\u0147': 'N', '\u0143': 'N',
+  '\u0110': 'D',
+}
+
+const SEPARATOR_CHARS: Record<SeparatorType, string> = {
+  hyphen: '-',
+  underscore: '_',
+  dot: '.',
+}
+
+export const defaultSlugOptions: SlugOptions = {
+  separator: 'hyphen',
+  lowercase: true,
+  maxLength: 0,
+  transliterate: true,
+}
+
+function transliterate(input: string): string {
+  let result = ''
+  for (const char of input) {
+    result += TRANSLITERATION_MAP[char] ?? char
+  }
+  return result
+}
+
+function stripDiacritics(input: string): string {
+  return input.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+}
+
+export function generateSlug(input: string, options: SlugOptions = defaultSlugOptions): Result<string> {
+  if (input === '') {
+    return err('EMPTY_INPUT', 'Please enter some input')
+  }
+
+  const sep = SEPARATOR_CHARS[options.separator]
+
+  let slug = input
+
+  // Step 1: transliterate known characters (before NFD to handle multi-char mappings like ss, ae)
+  if (options.transliterate) {
+    slug = transliterate(slug)
+  }
+
+  // Step 2: strip remaining diacritics via NFD decomposition
+  slug = stripDiacritics(slug)
+
+  // Step 3: apply case transformation
+  if (options.lowercase) {
+    slug = slug.toLowerCase()
+  }
+
+  // Step 4: replace non-alphanumeric characters (except the separator) with the separator
+  const safePattern = new RegExp(`[^a-zA-Z0-9${sep === '.' ? '\\.' : sep}]+`, 'g')
+  slug = slug.replace(safePattern, sep)
+
+  // Step 5: collapse consecutive separators
+  const escapedSep = sep === '.' ? '\\.' : sep
+  slug = slug.replace(new RegExp(`${escapedSep}{2,}`, 'g'), sep)
+
+  // Step 6: trim leading/trailing separators
+  slug = slug.replace(new RegExp(`^${escapedSep}|${escapedSep}$`, 'g'), '')
+
+  // Step 7: apply max length (truncate at separator boundary if possible)
+  if (options.maxLength > 0 && slug.length > options.maxLength) {
+    slug = slug.substring(0, options.maxLength)
+    // Avoid truncating in the middle of a word: trim at last separator
+    const lastSep = slug.lastIndexOf(sep)
+    if (lastSep > 0) {
+      slug = slug.substring(0, lastSep)
+    }
+    // Remove trailing separator after truncation
+    slug = slug.replace(new RegExp(`${escapedSep}$`), '')
+  }
+
+  if (slug === '') {
+    return err('EMPTY_RESULT', 'The input produces an empty slug')
+  }
+
+  return ok(slug)
+}

--- a/tests/tools/slug-generator.test.ts
+++ b/tests/tools/slug-generator.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest'
+import { generateSlug, defaultSlugOptions } from '../../src/tools/slug-generator'
+import type { SlugOptions } from '../../src/tools/slug-generator'
+
+describe('generateSlug', () => {
+  it('returns error for empty input', () => {
+    const result = generateSlug('')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.code).toBe('EMPTY_INPUT')
+    }
+  })
+
+  it('converts basic text to a slug', () => {
+    const result = generateSlug('Hello World')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('hello-world')
+    }
+  })
+
+  it('collapses multiple spaces into a single separator', () => {
+    const result = generateSlug('hello   world   foo')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('hello-world-foo')
+    }
+  })
+
+  it('strips leading and trailing separators', () => {
+    const result = generateSlug('  hello world  ')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('hello-world')
+    }
+  })
+
+  it('removes special characters', () => {
+    const result = generateSlug('hello! @world# $foo%')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('hello-world-foo')
+    }
+  })
+
+  it('transliterates accented characters', () => {
+    const result = generateSlug('Crème brûlée à la mode')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('creme-brulee-a-la-mode')
+    }
+  })
+
+  it('transliterates German characters', () => {
+    const result = generateSlug('Straße über München')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('strasse-uber-munchen')
+    }
+  })
+
+  it('transliterates Nordic characters', () => {
+    const result = generateSlug('Ærø Ødegård')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('aero-odegard')
+    }
+  })
+
+  it('transliterates Spanish characters', () => {
+    const result = generateSlug('El niño español')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('el-nino-espanol')
+    }
+  })
+
+  it('uses underscore separator', () => {
+    const opts: SlugOptions = { ...defaultSlugOptions, separator: 'underscore' }
+    const result = generateSlug('Hello World', opts)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('hello_world')
+    }
+  })
+
+  it('uses dot separator', () => {
+    const opts: SlugOptions = { ...defaultSlugOptions, separator: 'dot' }
+    const result = generateSlug('Hello World', opts)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('hello.world')
+    }
+  })
+
+  it('preserves case when lowercase is false', () => {
+    const opts: SlugOptions = { ...defaultSlugOptions, lowercase: false }
+    const result = generateSlug('Hello World', opts)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('Hello-World')
+    }
+  })
+
+  it('applies max length and truncates at separator boundary', () => {
+    const opts: SlugOptions = { ...defaultSlugOptions, maxLength: 10 }
+    const result = generateSlug('hello beautiful world', opts)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      // "hello-beautiful-world" is 21 chars, truncated to 10 is "hello-beau",
+      // then trimmed to last separator: "hello"
+      expect(result.value).toBe('hello')
+      expect(result.value.length).toBeLessThanOrEqual(10)
+    }
+  })
+
+  it('applies max length when slug fits exactly', () => {
+    const opts: SlugOptions = { ...defaultSlugOptions, maxLength: 11 }
+    const result = generateSlug('hello world', opts)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('hello-world')
+    }
+  })
+
+  it('handles max length with single word', () => {
+    const opts: SlugOptions = { ...defaultSlugOptions, maxLength: 5 }
+    const result = generateSlug('abcdefghij', opts)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('abcde')
+      expect(result.value.length).toBeLessThanOrEqual(5)
+    }
+  })
+
+  it('returns error when input contains only special characters', () => {
+    const result = generateSlug('!@#$%^&*()')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.code).toBe('EMPTY_RESULT')
+    }
+  })
+
+  it('handles input with numbers', () => {
+    const result = generateSlug('Product 123 Review')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('product-123-review')
+    }
+  })
+
+  it('skips transliteration when disabled', () => {
+    const opts: SlugOptions = { ...defaultSlugOptions, transliterate: false }
+    const result = generateSlug('café', opts)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      // Without transliteration, NFD strip still removes combining marks
+      expect(result.value).toBe('cafe')
+    }
+  })
+
+  it('handles mixed scripts and special chars', () => {
+    const result = generateSlug('Héllo & Wörld — Güten Tag!')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('hello-world-guten-tag')
+    }
+  })
+
+  it('handles tabs and newlines', () => {
+    const result = generateSlug('hello\tworld\nfoo')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('hello-world-foo')
+    }
+  })
+
+  it('does not apply max length when set to 0', () => {
+    const result = generateSlug('this is a fairly long title for testing purposes', {
+      ...defaultSlugOptions,
+      maxLength: 0,
+    })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toBe('this-is-a-fairly-long-title-for-testing-purposes')
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Add a new **Slug Generator** tool that converts any text into URL-friendly slugs
- Supports configurable separator (hyphen, underscore, dot), lowercase/preserve case toggle, optional max length with word-boundary truncation, and transliteration of accented characters across European languages (French, German, Spanish, Nordic, Czech, Polish, etc.)
- Live preview updates as the user types with no button click needed
- Includes i18n translations for all 5 supported languages (EN, IT, FR, ES, DE)

## Files created
- `src/tools/slug-generator.ts` -- pure logic with `generateSlug()` using `Result<T>` pattern
- `src/components/tools/SlugGenerator.tsx` -- Solid.js UI component with live preview
- `tests/tools/slug-generator.test.ts` -- 21 unit tests covering basic slugification, accented chars, special characters, separator options, max length, and edge cases

## Files modified
- `src/config/tools.ts` -- added tool registry entry (category: text-processing)
- `src/config/tool-components.ts` -- added lazy component mapping
- `src/i18n/messages/{en,it,fr,es,de}.json` -- added translations for all 5 languages

## Test plan
- [x] All 21 new unit tests pass
- [x] Full test suite passes (488 tests, 0 failures)
- [x] `npx astro check` shows no new errors (all 15 errors are pre-existing)
- [ ] Manual verification: navigate to `/en/tools/slug-generator` and test live preview
- [ ] Verify transliteration works for accented characters in multiple languages
- [ ] Test all separator options and max length truncation in the UI