### PR TITLE
fix: keep active tool visible and update generator defaults

### DIFF
--- a/e2e/tools/password-generator.spec.ts
+++ b/e2e/tools/password-generator.spec.ts
@@ -20,13 +20,13 @@ test.describe('Password Generator', () => {
     await expect(output).not.toBeEmpty()
   })
 
-  test('default generates 5 passwords (5 lines)', async ({ page }) => {
+  test('default generates 1 password (1 line)', async ({ page }) => {
     await page.getByRole('button', { name: 'Generate Password' }).click()
     const output = page.locator('[data-testid="output-panel"] textarea')
     await expect(output).not.toBeEmpty({ timeout: 5000 })
     const value = await output.inputValue()
     const lines = value.split('\n').filter((l) => l.trim() !== '')
-    expect(lines).toHaveLength(5)
+    expect(lines).toHaveLength(1)
   })
 
   test('each generated password is at least 16 chars (default length)', async ({ page }) => {

--- a/e2e/tools/pin-generator.spec.ts
+++ b/e2e/tools/pin-generator.spec.ts
@@ -25,13 +25,13 @@ test.describe('PIN Generator', () => {
     }
   })
 
-  test('default generates 10 PINs', async ({ page }) => {
+  test('default generates 1 PIN', async ({ page }) => {
     await page.getByRole('button', { name: 'Generate PINs' }).click()
     const output = page.locator('[data-testid="output-panel"] textarea')
     await expect(output).not.toBeEmpty({ timeout: 5000 })
     const value = await output.inputValue()
     const lines = value.split('\n').filter((l) => l.trim() !== '')
-    expect(lines).toHaveLength(10)
+    expect(lines).toHaveLength(1)
   })
 
   test('default PIN length is 4 digits', async ({ page }) => {

--- a/e2e/tools/username-generator.spec.ts
+++ b/e2e/tools/username-generator.spec.ts
@@ -19,13 +19,13 @@ test.describe('Username Generator', () => {
     await expect(page.locator('[data-testid="output-panel"] textarea')).not.toBeEmpty({ timeout: 5000 })
   })
 
-  test('default generates 10 usernames', async ({ page }) => {
+  test('default generates 1 username', async ({ page }) => {
     await page.getByRole('button', { name: 'Generate Usernames' }).click()
     const output = page.locator('[data-testid="output-panel"] textarea')
     await expect(output).not.toBeEmpty({ timeout: 5000 })
     const value = await output.inputValue()
     const lines = value.split('\n').filter((l) => l.trim() !== '')
-    expect(lines).toHaveLength(10)
+    expect(lines).toHaveLength(1)
   })
 
   test('style select shows all 4 options', async ({ page }) => {

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -20,7 +20,7 @@ for (const tool of toolRegistry) {
 }
 ---
 
-<nav class="flex flex-col gap-4 py-4" aria-label="Tool navigation">
+<nav class="flex flex-col gap-4 py-4" aria-label="Tool navigation" data-tool-sidebar>
   <!-- Favorites section (populated client-side) -->
   <div id={!mobile ? 'sidebar-favorites' : undefined} data-favorites-section class="hidden" data-lang={lang} data-current-path={currentPath}>
     <h3 class="mb-1.5 px-3 text-xs font-semibold uppercase tracking-wider text-amber-500 dark:text-amber-400">
@@ -122,7 +122,21 @@ for (const tool of toolRegistry) {
     document.querySelectorAll('[data-favorites-section]').forEach(updateFavoritesSection)
   }
 
+  function scrollActiveToolIntoView() {
+    var sidebars = document.querySelectorAll('[data-tool-sidebar]')
+    for (var i = 0; i < sidebars.length; i++) {
+      var sidebar = sidebars[i]
+      var activeLink = sidebar.querySelector('a[aria-current="page"]')
+      if (activeLink) {
+        activeLink.scrollIntoView({ block: 'center', inline: 'nearest' })
+      }
+    }
+  }
+
   initSidebarFavorites()
+  scrollActiveToolIntoView()
   document.addEventListener('astro:page-load', initSidebarFavorites)
+  document.addEventListener('astro:page-load', scrollActiveToolIntoView)
   window.addEventListener('favorites-updated', initSidebarFavorites)
+  window.addEventListener('favorites-updated', scrollActiveToolIntoView)
 </script>

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -127,16 +127,23 @@ for (const tool of toolRegistry) {
     for (var i = 0; i < sidebars.length; i++) {
       var sidebar = sidebars[i]
       var activeLink = sidebar.querySelector('a[aria-current="page"]')
-      if (activeLink) {
+      if (activeLink && activeLink.offsetParent !== null) {
         activeLink.scrollIntoView({ block: 'center', inline: 'nearest' })
       }
     }
   }
 
-  initSidebarFavorites()
-  scrollActiveToolIntoView()
-  document.addEventListener('astro:page-load', initSidebarFavorites)
-  document.addEventListener('astro:page-load', scrollActiveToolIntoView)
-  window.addEventListener('favorites-updated', initSidebarFavorites)
-  window.addEventListener('favorites-updated', scrollActiveToolIntoView)
+  if (!window.__sidebarListenersBound) {
+    document.addEventListener('astro:page-load', initSidebarFavorites)
+    document.addEventListener('astro:page-load', scrollActiveToolIntoView)
+    window.addEventListener('favorites-updated', initSidebarFavorites)
+    window.addEventListener('favorites-updated', scrollActiveToolIntoView)
+    window.__sidebarListenersBound = true
+  }
+
+  if (!window.__sidebarInitialSyncDone) {
+    initSidebarFavorites()
+    scrollActiveToolIntoView()
+    window.__sidebarInitialSyncDone = true
+  }
 </script>

--- a/src/components/tools/ApiKeyGenerator.tsx
+++ b/src/components/tools/ApiKeyGenerator.tsx
@@ -15,7 +15,7 @@ interface Props {
 export default function ApiKeyGenerator(props: Props) {
   const [prefix, setPrefix] = createSignal('sk_live_')
   const [length, setLength] = createSignal(32)
-  const [count, setCount] = createSignal(3)
+  const [count, setCount] = createSignal(1)
   const [format, setFormat] = createSignal<ApiKeyFormat>('alnum')
   const [output, setOutput] = createSignal('')
 

--- a/src/components/tools/HmacKeyGenerator.tsx
+++ b/src/components/tools/HmacKeyGenerator.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 export default function HmacKeyGenerator(props: Props) {
   const [size, setSize] = createSignal<HmacKeySize>(32)
-  const [count, setCount] = createSignal(3)
+  const [count, setCount] = createSignal(1)
   const [format, setFormat] = createSignal<HmacKeyFormat>('base64url')
   const [output, setOutput] = createSignal('')
 

--- a/src/components/tools/JwtSecretGenerator.tsx
+++ b/src/components/tools/JwtSecretGenerator.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 export default function JwtSecretGenerator(props: Props) {
   const [size, setSize] = createSignal<JwtSecretSize>(32)
-  const [count, setCount] = createSignal(3)
+  const [count, setCount] = createSignal(1)
   const [format, setFormat] = createSignal<JwtSecretFormat>('base64url')
   const [output, setOutput] = createSignal('')
 

--- a/src/components/tools/PassphraseGenerator.tsx
+++ b/src/components/tools/PassphraseGenerator.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 export default function PassphraseGenerator(props: Props) {
   const [wordCount, setWordCount] = createSignal(4)
-  const [count, setCount] = createSignal(5)
+  const [count, setCount] = createSignal(1)
   const [separator, setSeparator] = createSignal('-')
   const [output, setOutput] = createSignal('')
 

--- a/src/components/tools/PasswordGenerator.tsx
+++ b/src/components/tools/PasswordGenerator.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 export default function PasswordGenerator(props: Props) {
   const [length, setLength] = createSignal(16)
-  const [count, setCount] = createSignal(5)
+  const [count, setCount] = createSignal(1)
   const [uppercase, setUppercase] = createSignal(true)
   const [lowercase, setLowercase] = createSignal(true)
   const [numbers, setNumbers] = createSignal(true)

--- a/src/components/tools/PinGenerator.tsx
+++ b/src/components/tools/PinGenerator.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 export default function PinGenerator(props: Props) {
   const [length, setLength] = createSignal(4)
-  const [count, setCount] = createSignal(10)
+  const [count, setCount] = createSignal(1)
   const [unique, setUnique] = createSignal(true)
   const [output, setOutput] = createSignal('')
   const [error, setError] = createSignal<string | null>(null)

--- a/src/components/tools/SaltGenerator.tsx
+++ b/src/components/tools/SaltGenerator.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 export default function SaltGenerator(props: Props) {
   const [size, setSize] = createSignal<SaltSize>(16)
-  const [count, setCount] = createSignal(5)
+  const [count, setCount] = createSignal(1)
   const [format, setFormat] = createSignal<SaltFormat>('base64url')
   const [output, setOutput] = createSignal('')
 

--- a/src/components/tools/UsernameGenerator.tsx
+++ b/src/components/tools/UsernameGenerator.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 export default function UsernameGenerator(props: Props) {
   const [style, setStyle] = createSignal<UsernameStyle>('random')
-  const [count, setCount] = createSignal(10)
+  const [count, setCount] = createSignal(1)
   const [output, setOutput] = createSignal('')
   const [error, setError] = createSignal<string | null>(null)
 


### PR DESCRIPTION
## Summary
- Keep the selected tool centered in the left sidebar after navigation.
- Lower several generator defaults to `1` where appropriate.

## Notes
- No automated tests were run for this change.
