### PR TITLE
Add GitHub Pages project landing page (docs/)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Tools Collection — small, sharp tools for everyday work</title>
+<meta name="description" content="A collection of 53 fast, private, browser-based developer tools — formatters, generators, converters and inspectors. Everything runs in your browser. Nothing is ever uploaded." />
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%23f7f8fa'/%3E%3Crect x='20' y='20' width='24' height='24' rx='5' fill='%234f46e5' transform='rotate(45 32 32)'/%3E%3C/svg%3E" />
+<meta property="og:title" content="Tools Collection — small, sharp tools for everyday work" />
+<meta property="og:description" content="53 fast, private, browser-based developer tools. Everything runs in your browser. Nothing is ever uploaded." />
+<meta property="og:type" content="website" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500&display=swap" rel="stylesheet" />
+<style>
+  :root {
+    --bg: #f7f8fa; --bg-2: #eef1f5; --card: #ffffff;
+    --ink: #0b0f1a; --ink-2: #475467; --ink-3: #667085;
+    --line: #e4e7ec; --line-2: #d0d5dd;
+    --accent: #4f46e5; --accent-ink: #4338ca; --accent-soft: #eae8fd;
+    --c-text:#2563eb; --c-gen:#7c3aed; --c-extract:#0891b2; --c-analyze:#d97706;
+    --c-secure:#e11d48; --c-convert:#059669; --c-dev:#4f46e5; --c-util:#db2777;
+    --shadow: 0 8px 24px -14px rgba(11,15,26,.22);
+    --font-display: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
+    --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;
+    --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+    --maxw: 1080px;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0b0e14; --bg-2: #0f131b; --card: #131722;
+      --ink: #e6e9ef; --ink-2: #98a2b3; --ink-3: #6b7686;
+      --line: #1f2533; --line-2: #2a3140;
+      --accent: #818cf8; --accent-ink: #a5b4fc; --accent-soft: #1e1b3a;
+      --c-text:#60a5fa; --c-gen:#a78bfa; --c-extract:#22d3ee; --c-analyze:#fbbf24;
+      --c-secure:#fb7185; --c-convert:#34d399; --c-dev:#818cf8; --c-util:#f472b6;
+      --shadow: 0 10px 30px -16px rgba(0,0,0,.7);
+    }
+  }
+  * { box-sizing: border-box; margin: 0; }
+  html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
+  body {
+    font-family: var(--font-sans); background: var(--bg); color: var(--ink);
+    line-height: 1.6; -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility;
+  }
+  a { color: inherit; text-decoration: none; }
+  ::selection { background: var(--accent-soft); color: var(--accent-ink); }
+  svg { display: block; }
+  .wrap { width: 100%; max-width: var(--maxw); margin-inline: auto; padding-inline: clamp(16px, 5vw, 40px); }
+
+  /* header */
+  header {
+    position: sticky; top: 0; z-index: 10;
+    background: color-mix(in oklab, var(--bg) 85%, transparent);
+    backdrop-filter: blur(12px); border-bottom: 1px solid var(--line);
+  }
+  .nav { display: flex; align-items: center; gap: 14px; height: 64px; }
+  .brand { display: flex; align-items: baseline; gap: 10px; }
+  .brand .mark { width: 11px; height: 11px; background: var(--accent); border-radius: 2px; transform: rotate(45deg); align-self: center; }
+  .brand .word { font-family: var(--font-display); font-size: 20px; font-weight: 700; letter-spacing: -.02em; }
+  .brand .ver { font-family: var(--font-mono); font-size: 11px; color: var(--ink-3); border: 1px solid var(--line-2); padding: 1px 6px; border-radius: 5px; align-self: center; }
+  .nav .spacer { flex: 1; }
+  .nav a.ghost { color: var(--ink-2); font-weight: 600; font-size: 14px; padding: 8px 12px; border-radius: 8px; }
+  .nav a.ghost:hover { color: var(--ink); background: color-mix(in oklab, var(--ink) 6%, transparent); }
+
+  .btn {
+    display: inline-flex; align-items: center; gap: 8px; height: 44px; padding: 0 20px;
+    border-radius: 9px; font-weight: 600; font-size: 15px; border: 1px solid var(--line-2);
+    background: var(--card); color: var(--ink); transition: all .16s; white-space: nowrap;
+  }
+  .btn:hover { border-color: var(--accent); color: var(--accent); transform: translateY(-1px); }
+  .btn-primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+  .btn-primary:hover { background: var(--accent-ink); border-color: var(--accent-ink); color: #fff; }
+  .btn svg { width: 18px; height: 18px; stroke: currentColor; fill: none; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+
+  /* hero */
+  .hero { padding-block: clamp(56px, 9vw, 110px) clamp(36px, 5vw, 64px); text-align: center; }
+  .eyebrow { font-size: 12px; font-weight: 700; letter-spacing: .16em; text-transform: uppercase; color: var(--accent); }
+  .hero h1 {
+    font-family: var(--font-display); font-weight: 700; letter-spacing: -.035em;
+    font-size: clamp(40px, 7vw, 76px); line-height: 1.02; margin-top: 18px; text-wrap: balance;
+  }
+  .hero h1 em { font-style: normal; color: var(--accent); }
+  .hero p.lede { margin: 22px auto 0; max-width: 60ch; font-size: clamp(16px, 1.8vw, 19px); color: var(--ink-2); }
+  .cta { margin-top: 34px; display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+
+  /* stats */
+  .stats { display: flex; flex-wrap: wrap; justify-content: center; gap: 10px; margin-top: 38px; }
+  .stat { display: inline-flex; align-items: center; gap: 7px; height: 34px; padding: 0 14px; border-radius: 999px; border: 1px solid var(--line-2); background: var(--card); font-size: 13.5px; font-weight: 600; color: var(--ink-2); }
+  .stat b { color: var(--ink); }
+  .stat .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--accent); }
+
+  /* features */
+  section.block { padding-block: clamp(40px, 6vw, 72px); }
+  .section-title { font-family: var(--font-display); font-weight: 600; letter-spacing: -.02em; font-size: clamp(24px, 3vw, 32px); text-align: center; }
+  .section-sub { text-align: center; color: var(--ink-3); margin-top: 8px; }
+  .grid { display: grid; gap: 16px; margin-top: 36px; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); }
+  .card { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 22px; transition: transform .2s, border-color .2s, box-shadow .2s; }
+  .card:hover { transform: translateY(-3px); border-color: var(--line-2); box-shadow: var(--shadow); }
+  .tile { display: grid; place-items: center; width: 42px; height: 42px; border-radius: 9px; color: var(--tint, var(--accent)); background: color-mix(in oklab, var(--tint, var(--accent)) 12%, var(--card)); border: 1px solid color-mix(in oklab, var(--tint, var(--accent)) 24%, transparent); margin-bottom: 14px; }
+  .tile svg { width: 22px; height: 22px; stroke: currentColor; fill: none; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
+  .card h3 { font-family: var(--font-display); font-size: 17px; font-weight: 600; letter-spacing: -.01em; }
+  .card p { color: var(--ink-3); font-size: 14px; margin-top: 6px; }
+
+  .band { background: var(--bg-2); border-block: 1px solid var(--line); }
+
+  /* footer */
+  footer { border-top: 1px solid var(--line); padding-block: 32px; margin-top: 24px; }
+  .foot { display: flex; flex-wrap: wrap; align-items: center; gap: 14px; justify-content: space-between; color: var(--ink-3); font-size: 14px; }
+  .foot a:hover { color: var(--accent); }
+  .foot .links { display: flex; gap: 20px; }
+
+  @media (max-width: 640px) {
+    .nav { gap: 8px; }
+    .brand .ver { display: none; }
+    .nav a.ghost[href="#features"], .nav a.ghost[href="#categories"] { display: none; }
+  }
+</style>
+</head>
+<body>
+  <header>
+    <nav class="wrap nav">
+      <a class="brand" href="#top" aria-label="Tools Collection">
+        <span class="mark"></span><span class="word">Tools Collection</span><span class="ver">v1.6.0</span>
+      </a>
+      <span class="spacer"></span>
+      <a class="ghost" href="#features">Features</a>
+      <a class="ghost" href="#categories">Categories</a>
+      <a class="ghost" href="https://github.com/amargiovanni/tools-collection" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+
+  <main id="top">
+    <section class="hero wrap">
+      <p class="eyebrow">A quiet workshop of small, sharp tools</p>
+      <h1>Small, <em>sharp</em> tools for everyday work.</h1>
+      <p class="lede">A workbench of fast, private utilities for text, code and crypto — formatters, generators, converters and inspectors. Everything runs in your browser. Nothing is ever uploaded.</p>
+      <div class="cta">
+        <a class="btn btn-primary" href="https://tools.margiovanni.it/" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+          Open the app
+        </a>
+        <a class="btn" href="https://github.com/amargiovanni/tools-collection" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49 0-.24-.01-.88-.01-1.73-2.78.62-3.37-1.37-3.37-1.37-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.63.07-.63 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.37-2.22-.26-4.55-1.14-4.55-5.05 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.7 0 0 .84-.27 2.75 1.05a9.3 9.3 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.4.2 2.44.1 2.7.64.72 1.03 1.63 1.03 2.75 0 3.92-2.34 4.78-4.57 5.04.36.32.68.94.68 1.9 0 1.37-.01 2.47-.01 2.81 0 .27.18.6.69.49A10.02 10.02 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>
+          View on GitHub
+        </a>
+      </div>
+      <div class="stats">
+        <span class="stat"><span class="dot"></span><b>53</b>&nbsp;tools</span>
+        <span class="stat"><b>8</b>&nbsp;categories</span>
+        <span class="stat"><b>100%</b>&nbsp;client-side</span>
+        <span class="stat"><b>5</b>&nbsp;languages</span>
+        <span class="stat"><b>MIT</b>&nbsp;licensed</span>
+      </div>
+    </section>
+
+    <section id="features" class="block band">
+      <div class="wrap">
+        <h2 class="section-title">Built for speed and privacy</h2>
+        <p class="section-sub">No accounts, no tracking — your data never leaves the tab.</p>
+        <div class="grid">
+          <div class="card">
+            <span class="tile" style="--tint:var(--c-secure)"><svg viewBox="0 0 24 24"><path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6z"/><path d="M9 12l2 2 4-4"/></svg></span>
+            <h3>100% client-side</h3>
+            <p>Every tool runs locally in your browser. Nothing is uploaded (except optional QR generation).</p>
+          </div>
+          <div class="card">
+            <span class="tile" style="--tint:var(--c-gen)"><svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg></span>
+            <h3>Command palette</h3>
+            <p>Press <strong>⌘/Ctrl+K</strong> to jump to any tool or action; <strong>/</strong> to quick-open, <strong>⌘↵</strong> to run.</p>
+          </div>
+          <div class="card">
+            <span class="tile" style="--tint:var(--c-analyze)"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4 12H2M22 12h-2M5 5l1.5 1.5M17.5 17.5 19 19M19 5l-1.5 1.5M6.5 17.5 5 19"/></svg></span>
+            <h3>Light &amp; dark</h3>
+            <p>A refined dev-tool theme with light, dark and system modes — easy on the eyes, day or night.</p>
+          </div>
+          <div class="card">
+            <span class="tile" style="--tint:var(--c-convert)"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8.5"/><path d="M3.5 12h17"/><path d="M12 3.5c2.5 2.3 4 5.3 4 8.5s-1.5 6.2-4 8.5c-2.5-2.3-4-5.3-4-8.5s1.5-6.2 4-8.5z"/></svg></span>
+            <h3>Five languages</h3>
+            <p>Fully translated interface in English, Italian, Spanish, French and German.</p>
+          </div>
+          <div class="card">
+            <span class="tile" style="--tint:var(--c-dev)"><svg viewBox="0 0 24 24"><path d="M9 8l-4 4 4 4"/><path d="M15 8l4 4-4 4"/></svg></span>
+            <h3>Open source</h3>
+            <p>Astro + Solid.js + TypeScript (strict) + Tailwind v4. MIT licensed. Contributions welcome.</p>
+          </div>
+          <div class="card">
+            <span class="tile" style="--tint:var(--c-util)"><svg viewBox="0 0 24 24"><path d="M12 3.5l2.6 5.4 5.9.8-4.3 4.1 1 5.9L12 17l-5.2 2.7 1-5.9-4.3-4.1 5.9-.8z"/></svg></span>
+            <h3>Favorites &amp; recents</h3>
+            <p>Star the tools you use most and jump back into recent ones — all stored locally.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="categories" class="block">
+      <div class="wrap">
+        <h2 class="section-title">53 tools across 8 categories</h2>
+        <p class="section-sub">Text, generation, extraction, analysis, security, conversion, development and more.</p>
+        <div class="grid">
+          <div class="card"><span class="tile" style="--tint:var(--c-text)"><svg viewBox="0 0 24 24"><path d="M4 7V4h16v3"/><path d="M9 20h6"/><path d="M12 4v16"/></svg></span><h3>Text Processing</h3><p>Reshape, clean and reorder lines of text.</p></div>
+          <div class="card"><span class="tile" style="--tint:var(--c-gen)"><svg viewBox="0 0 24 24"><path d="M12 3.5l1.6 4.4 4.4 1.6-4.4 1.6L12 15.5 10.4 11l-4.4-1.5 4.4-1.6z"/><path d="M19 14.5l.7 1.8 1.8.7-1.8.7-.7 1.8-.7-1.8-1.8-.7 1.8-.7z"/></svg></span><h3>Generators</h3><p>Conjure keys, ids, passwords and placeholder data.</p></div>
+          <div class="card"><span class="tile" style="--tint:var(--c-extract)"><svg viewBox="0 0 24 24"><path d="M3 5h18l-7 8v5.5l-4 2V13z"/></svg></span><h3>Extraction</h3><p>Pull structured fragments out of raw text.</p></div>
+          <div class="card"><span class="tile" style="--tint:var(--c-analyze)"><svg viewBox="0 0 24 24"><path d="M4 20V10"/><path d="M10 20V4"/><path d="M16 20v-7"/><path d="M3 20h18"/></svg></span><h3>Analysis</h3><p>Measure and inspect what you paste in.</p></div>
+          <div class="card"><span class="tile" style="--tint:var(--c-secure)"><svg viewBox="0 0 24 24"><path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6z"/></svg></span><h3>Security</h3><p>Keys, hashes and credentials — generated locally.</p></div>
+          <div class="card"><span class="tile" style="--tint:var(--c-convert)"><svg viewBox="0 0 24 24"><path d="M17 4l3 3-3 3"/><path d="M20 7H8a4 4 0 0 0-4 4"/><path d="M7 20l-3-3 3-3"/><path d="M4 17h12a4 4 0 0 0 4-4"/></svg></span><h3>Converters</h3><p>Translate between encodings and formats.</p></div>
+          <div class="card"><span class="tile" style="--tint:var(--c-dev)"><svg viewBox="0 0 24 24"><path d="M9 8l-4 4 4 4"/><path d="M15 8l4 4-4 4"/></svg></span><h3>Development</h3><p>Format, validate and decode developer payloads.</p></div>
+          <div class="card"><span class="tile" style="--tint:var(--c-util)"><svg viewBox="0 0 24 24"><path d="M14.5 5.5a3.8 3.8 0 0 0-5 5L4 16v4h4l5.5-5.5a3.8 3.8 0 0 0 5-5l-2.8 2.8-2.2-.6-.6-2.2z"/></svg></span><h3>Utilities</h3><p>Everyday helpers that did not fit a box.</p></div>
+        </div>
+        <div class="cta" style="margin-top:40px">
+          <a class="btn btn-primary" href="https://tools.margiovanni.it/" target="_blank" rel="noopener">
+            <svg viewBox="0 0 24 24"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+            Explore all tools
+          </a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="wrap foot">
+      <a class="brand" href="#top"><span class="mark"></span><span class="word" style="font-size:17px">Tools Collection</span></a>
+      <nav class="links">
+        <a href="https://tools.margiovanni.it/" target="_blank" rel="noopener">Live app</a>
+        <a href="https://github.com/amargiovanni/tools-collection" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/amargiovanni/tools-collection/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
+      </nav>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## What

Adds a self-contained **GitHub Pages project landing page** under `docs/` (source: `main` → `/docs`).

- On-brand with the app's dev-tool theme: cool slate + electric indigo, Space Grotesk / Inter / JetBrains Mono, light + dark via `prefers-color-scheme`.
- Hero with CTAs (**Open the app** → `https://tools.margiovanni.it/`, **View on GitHub**), stat pills, six feature highlights, and the eight tool categories.
- Fully responsive — verified no horizontal overflow at 390px (the header collapses to brand + GitHub on phones).
- `docs/.nojekyll` so Pages serves assets without Jekyll processing.

No build step; the page is static HTML and independent of the Astro app (which stays on its existing host). The Astro build/tests are unaffected (`docs/` is outside `src/`/`public/`).

## Serving it on github.io (no custom domain)

This branch intentionally contains **no `CNAME` file**, so nothing here forces a custom domain. To serve at `https://amargiovanni.github.io/tools-collection/`:

1. Merge this PR.
2. **Settings → Pages → Custom domain**: clear `blog.margiovanni.it` and **Save** (this is what's currently forcing that domain — it's stored in repo settings, not in the repo files).
3. **Settings → Pages → Source**: *Deploy from a branch* → `main` → `/docs` → **Save**.

https://claude.ai/code/session_011oU6LdcwaFS7b5Gf7kwUmA

---
_Generated by [Claude Code](https://claude.ai/code/session_011oU6LdcwaFS7b5Gf7kwUmA)_